### PR TITLE
Delete "/api" from postTransaction function

### DIFF
--- a/InsightClient/VIClient.swift
+++ b/InsightClient/VIClient.swift
@@ -20,7 +20,7 @@ public class VIClient: VIClientProtocol {
 
     public func postTransaction(rawTransaction: String, completion: @escaping (String?) -> Void) {
         let parameterDictionary = ["rawtx" : rawTransaction]
-        let url = self.url("/api/tx/send")
+        let url = self.url("/tx/send")
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"


### PR DESCRIPTION
Endpoint is already build in url function, if left url will be xxx/api/api/tx/send